### PR TITLE
Share same client for different queues

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@
 A simple and fast redis based queue, supports both *fifo* and *lifo*.
 
 ## Install
-```
+
+```bash
 npm i shape-of-q
 ```
 
 ## Usage
+
 ```js
 const q = require('shape-of-q')('myqueue')
 q.on('error', console.log)
@@ -24,6 +26,7 @@ q.pull({ polling: true }, (msg, done) => {
 ```
 
 Async await is supported as well!
+
 ```js
 q.pull({ polling: true }, async msg => {
   console.log(msg)
@@ -33,8 +36,11 @@ q.pull({ polling: true }, async msg => {
 ## API
 
 ### Constructor
-Create a new queue, the queue name parameter is mandatory.<br>
+
+Create a new queue, the queue name parameter is mandatory.
+
 Options:
+
 ```js
 const q = require('shape-of-q')('myqueue', {
   encoding: 'json', // default: null
@@ -47,16 +53,22 @@ const q = require('shape-of-q')('myqueue', {
 `shape-of-q` is an event emitter and you should listen for the `error` event.
 
 #### `push`
-Add a new message to the queue.<br>
+
+Add a new message to the queue.
+
 If the encoding has been set to `'json'` you can pass plain objects.
+
 ```js
 q.push('hello')
 ```
 
 #### `pull`
-Retrieve a single message from the queue.<br>
+
+Retrieve a single message from the queue.
+
 To enable polling, pass `{ polling: true }` as option and `pollingInterval` if you want to customize the interval (must be expressed in seconds).<br>
 The api supports both classic callbacks and async await.
+
 ```js
 // callbacks
 q.pull({ polling: true }, (msg, done) => {
@@ -69,10 +81,13 @@ q.pull({ polling: true }, async msg => {
   console.log(msg)
 })
 ```
+
 If you pass an error to `done` or return an error in the async version the message will be put back in the queue.
 
 #### `list`
+
 Get all elements in the queue.
+
 ```js
 q.list((err, msg) => {
   console.log(msg)
@@ -80,12 +95,15 @@ q.list((err, msg) => {
 ```
 
 #### `stop`
+
 Stops the polling and closes the connection to redis.
+
 ```js
 q.stop()
 ```
 
 ## License
+
 MIT
 
 Copyright © 2018 Tomas Della Vedova

--- a/index.js
+++ b/index.js
@@ -49,14 +49,15 @@ ShapeOfQ.prototype.pull = function (opts, callback) {
       if (polling === true && that.stopping === false) {
         debug(`Queue is empty, read again in ${pollingInterval} seconds`)
         setTimeout(readQueue, pollingInterval * 1000)
+        return
       } else {
         debug('Queue is empty')
       }
-      return
+    } else {
+      debug('Got a message:', result)
     }
 
-    debug('Got a message:', result)
-    if (that.encoding === 'json') {
+    if (that.encoding === 'json' && result !== null) {
       try {
         result = JSON.parse(result)
       } catch (err) {

--- a/test.js
+++ b/test.js
@@ -139,3 +139,21 @@ test('Share same client', t => {
     done()
   })
 })
+
+test('Not polling mode', t => {
+  t.plan(2)
+  const q = ShapeOfQ(randomstring.generate())
+  q.on('error', t.error)
+  q.push('hello')
+
+  q.pull((msg, done) => {
+    t.strictEqual(msg, 'hello')
+    done()
+
+    q.pull((msg, done) => {
+      t.strictEqual(msg, null)
+      q.stop(noop)
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Moved from `brpop` to `rpop`, now the timeout is handled directly by us.
In this way we can share the same client among different queues.