### PR TITLE
Custom encoder/decoder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,17 @@ const q = require('shape-of-q')('myqueue', {
   encoding: 'json', // default: null
   type: 'lifo', // default: 'fifo'
   client: Object, // custom redis client
-  host: '127.0.0.1' // redis host for the internal client
+  host: '127.0.0.1' // redis host for the internal client,
+  encoder: msgpack.encode, // default null
+  decoder: msgpack.decode, // default null
+  binaryData: true // default false
 })
 ```
 
 `shape-of-q` is an event emitter and you should listen for the `error` event.
+
+If you are working with objects and want to speed up the serialization you can use the `encoder` and `decoder` option, both of them must be sync functions.<br>
+If the `encoder` produces binary data make sure to pass `{ binaryData: true }` as option.
 
 #### `push`
 

--- a/bench.js
+++ b/bench.js
@@ -1,0 +1,76 @@
+'use strict'
+
+// once the benchmark has finished you must kill the process
+
+const bench = require('fastbench')
+const ShapeOfQ = require('./index')
+const randomstring = require('randomstring')
+const msgpack = require('msgpack5')()
+const protobuf = require('protocol-buffers')
+const messages = protobuf(`
+  message hello {
+    required string hello = 1;
+    required float answer = 2;
+  }
+`)
+
+const stringQ = ShapeOfQ(randomstring.generate())
+const jsonQ = ShapeOfQ(randomstring.generate(), { encoding: 'json' })
+const msgpackQ = ShapeOfQ(randomstring.generate(), {
+  encoder: msgpack.encode,
+  decoder: msgpack.decode,
+  binaryData: true
+})
+const protobufQ = ShapeOfQ(randomstring.generate(), {
+  encoder: messages.hello.encode,
+  decoder: messages.hello.decode,
+  binaryData: true
+})
+
+const run = bench([
+  function benchStringQPush (finish) {
+    stringQ.push('hello world 42')
+    finish()
+  },
+  function benchStringQPull (finish) {
+    stringQ.pull((msg, done) => {
+      done()
+      finish()
+    })
+  },
+
+  function benchJsonQPush (finish) {
+    jsonQ.push({ hello: 'world', answer: 42 })
+    finish()
+  },
+  function benchJsonQPull (finish) {
+    jsonQ.pull((msg, done) => {
+      done()
+      finish()
+    })
+  },
+
+  function benchMsgpackQPush (finish) {
+    msgpackQ.push({ hello: 'world', answer: 42 })
+    finish()
+  },
+  function benchMsgpackQPull (finish) {
+    msgpackQ.pull((msg, done) => {
+      done()
+      finish()
+    })
+  },
+
+  function benchjProtobufQPush (finish) {
+    protobufQ.push({ hello: 'world', answer: 42 })
+    finish()
+  },
+  function benchjProtobufQPull (finish) {
+    protobufQ.pull((msg, done) => {
+      done()
+      finish()
+    })
+  }
+], 1000)
+
+run(run)

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "ioredis": "^3.2.2"
   },
   "devDependencies": {
+    "fastbench": "^1.0.1",
+    "msgpack5": "^4.0.2",
+    "protocol-buffers": "^4.0.4",
     "randomstring": "^1.1.5",
     "standard": "^11.0.1",
     "tap": "^11.1.3"


### PR DESCRIPTION
As titled.
Example:
```js
const protobuf = require('protocol-buffers')
const messages = protobuf(`
  message hello {
    required string hello = 1;
    required float answer = 2;
  }
`)

const q = require('shape-of-q')('proto', {
  encoder: messages.hello.encode,
  decoder: messages.hello.decode,
  binaryData: true
})

q.push({ hello: 'world', answer: 42 })

q.pull((msg, done) => {
  console.log(msg) // { hello: 'world', answer: 42 }
  done()
})
```

I've also added a benchmark runner ;)